### PR TITLE
Fixing styles not passed into image

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -72,7 +72,7 @@ export function GalleryItem({
         accessibilityHint="">
         <Image
           source={{uri: image.thumb}}
-          style={[a.flex_1]}
+          style={[a.flex_1, imageStyle]}
           accessible={true}
           accessibilityLabel={image.alt}
           accessibilityHint=""


### PR DESCRIPTION
Why?
To fix this issue https://github.com/speakeasy-social/speakeasy/issues/8

How to test this?
Visit this post on local and check if the images are not cropped
http://localhost:19006/profile/stephonee.bsky.social/post/3ljr2cb4jrc2x

Currently, the screen does show the whole image but I think I can't think of what to do for the outside container, whether it should shrink to the size of the image or should it stay fixed

![image](https://github.com/user-attachments/assets/fe709abf-a161-43f6-b6a1-e120ff997f99)
