### PR TITLE
Bug/bluesky references

### DIFF
--- a/src/components/ProgressGuide/List.tsx
+++ b/src/components/ProgressGuide/List.tsx
@@ -50,7 +50,7 @@ export function ProgressGuideList({style}: {style?: StyleProp<ViewStyle>}) {
               current={guide.numFollows + 1}
               total={10 + 1}
               title={_(msg`Follow 10 accounts`)}
-              subtitle={_(msg`Bluesky is better with friends!`)}
+              subtitle={_(msg`Speakeasy is better with friends!`)}
             />
             <FollowDialog guide={guide} />
           </>
@@ -67,7 +67,7 @@ export function ProgressGuideList({style}: {style?: StyleProp<ViewStyle>}) {
               current={guide.numFollows + 1}
               total={7 + 1}
               title={_(msg`Follow 7 accounts`)}
-              subtitle={_(msg`Bluesky is better with friends!`)}
+              subtitle={_(msg`Speakeasy is better with friends!`)}
             />
           </>
         )}

--- a/src/locale/locales/an/messages.po
+++ b/src/locale/locales/an/messages.po
@@ -1099,8 +1099,8 @@ msgstr "Bluesky ye un ret ubierto an que puez triar lo furnidor d'aloch. Si yes 
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky ye millor con amigos!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy ye millor con amigos!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/an/messages.po
+++ b/src/locale/locales/an/messages.po
@@ -7878,8 +7878,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Hemos ninviau unatro correu electronico de verificación a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperemos que lo pases bien. Recuerda, Bluesky ye:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperemos que lo pases bien. Recuerda, Speakeasy ye:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/ast/messages.po
+++ b/src/locale/locales/ast/messages.po
@@ -8401,8 +8401,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Unviémoste otru mensaxes de verificación a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperamos que lo pases podre. Recuerda que Bluesky ye:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperamos que lo pases podre. Recuerda que Speakeasy ye:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/ast/messages.po
+++ b/src/locale/locales/ast/messages.po
@@ -1138,8 +1138,8 @@ msgstr "Bluesky ye una rede abierta onde pues escoyer l'agospiador. Si yes desen
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "¡Bluesky ye meyor con compaña!"
+msgid "Speakeasy is better with friends!"
+msgstr "¡Speakeasy ye meyor con compaña!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -1375,8 +1375,8 @@ msgstr "Bluesky és una xarxa oberta on pots escollir el teu proveïdor d'allotj
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky és millor amb col·legues!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy és millor amb col·legues!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:82

--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -10142,8 +10142,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Hem enviat un altre correu de verificació a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperem que t'ho passis pipa. Recorda que Bluesky és:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperem que t'ho passis pipa. Recorda que Speakeasy és:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -1190,8 +1190,8 @@ msgstr ""
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Mit Freunden ist Bluesky besser!"
+msgid "Speakeasy is better with friends!"
+msgstr "Mit Freunden ist Speakeasy besser!"
 
 #: src/components/dialogs/nuxs/TenMillion/index.tsx:206
 #~ msgid "Bluesky now has over 10 million users, and I was #{0}!"

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -9416,8 +9416,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr ""
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Wir hoffen, dass du eine schöne Zeit hast. Denke daran, Bluesky ist:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Wir hoffen, dass du eine schöne Zeit hast. Denke daran, Speakeasy ist:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/el/messages.po
+++ b/src/locale/locales/el/messages.po
@@ -1098,8 +1098,8 @@ msgstr "Το Bluesky είναι ένα ανοιχτό δίκτυο όπου μπ
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Το Bluesky είναι καλύτερο με φίλους!"
+msgid "Speakeasy is better with friends!"
+msgstr "Το Speakeasy είναι καλύτερο με φίλους!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/el/messages.po
+++ b/src/locale/locales/el/messages.po
@@ -7894,8 +7894,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Στείλαμε ένα νέο email επαλήθευσης στη διεύθυνση <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Ελπίζουμε να περάσετε υπέροχα. Θυμηθείτε, το Bluesky είναι:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Ελπίζουμε να περάσετε υπέροχα. Θυμηθείτε, το Speakeasy είναι:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/en-GB/messages.po
+++ b/src/locale/locales/en-GB/messages.po
@@ -8401,7 +8401,7 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr ""
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
 msgstr ""
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29

--- a/src/locale/locales/en-GB/messages.po
+++ b/src/locale/locales/en-GB/messages.po
@@ -1138,7 +1138,7 @@ msgstr ""
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
+msgid "Speakeasy is better with friends!"
 msgstr ""
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -8401,7 +8401,7 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr ""
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
 msgstr ""
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -1138,7 +1138,7 @@ msgstr ""
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
+msgid "Speakeasy is better with friends!"
 msgstr ""
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -9299,8 +9299,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Hemos enviado otro correo electrónico de verificación a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperemos que la pases bien. Recuerda, Bluesky es:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperemos que la pases bien. Recuerda, Speakeasy es:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -1272,8 +1272,8 @@ msgstr "Bluesky es una red abierta donde puedes elegir tu proveedor de alojamien
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "¡Bluesky es mejor con amigos!"
+msgid "Speakeasy is better with friends!"
+msgstr "!Speakeasy es mejor con amigos!"
 
 #: src/components/dialogs/nuxs/TenMillion/index.tsx:206
 #~ msgid "Bluesky now has over 10 million users, and I was #{0}!"

--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -7722,8 +7722,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Olemme lähettäneet toisen vahvistussähköpostiviestin osoitteeseen <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Toivomme sinulle ihania hetkiä. Muista, että Bluesky on"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Toivomme sinulle ihania hetkiä. Muista, että Speakeasy on"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -1050,8 +1050,8 @@ msgstr "Bluesky on avoin verkosto, jossa voit valita hostauspalveluntarjoajasi. 
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky on parempi kavereiden kanssa!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy on parempi kavereiden kanssa!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -7722,8 +7722,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Nous avons envoyé un autre e-mail de vérification à <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Nous espérons que vous passerez un excellent moment. N’oubliez pas que Bluesky est :"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Nous espérons que vous passerez un excellent moment. N’oubliez pas que Speakeasy est :"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -1050,8 +1050,8 @@ msgstr "Bluesky est un réseau ouvert où vous pouvez choisir votre hébergeur. 
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky est meilleur entre ami·e·s !"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy est meilleur entre ami·e·s !"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -1137,8 +1137,8 @@ msgstr "Is líonra oscailte é Bluesky, lenar féidir do sholáthraí óstála f
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Déanann mathshlua meidhréis ar Bluesky!"
+msgid "Speakeasy is better with friends!"
+msgstr "Déanann mathshlua meidhréis ar Speakeasy!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -8400,8 +8400,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Sheolamar ríomhphost dearbhaithe eile chuig <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Tá súil againn go mbeidh an-chraic agat anseo. Ná déan dearmad go bhfuil Bluesky:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Tá súil againn go mbeidh an-chraic agat anseo. Ná déan dearmad go bhfuil Speakeasy:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -9304,8 +9304,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Enviamos outro correo electrónico de verificación a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperamos que o pases de marabilla. Lembra que Bluesky é:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperamos que o pases de marabilla. Lembra que Speakeasy é:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -1272,8 +1272,8 @@ msgstr "Bluesky é unha rede aberta onde podes elixir o teu proveedor de aloxame
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky é mellor con amizades!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy é mellor con amizades!"
 
 #: src/components/dialogs/nuxs/TenMillion/index.tsx:206
 #~ msgid "Bluesky now has over 10 million users, and I was #{0}!"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -8852,8 +8852,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "हमने <0>{0}</0> को एक और सत्यापन ईमेल भेजा है।"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "हम आशा करते हैं आपका समय शानदार हो। याद रखें, Bluesky है:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "हम आशा करते हैं आपका समय शानदार हो। याद रखें, Speakeasy है:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -1216,8 +1216,8 @@ msgstr "Bluesky एक खुला नेटवर्क है जहाँ �
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky दोस्तों के साथ बेहतर है!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy दोस्तों के साथ बेहतर है!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:82

--- a/src/locale/locales/hu/messages.po
+++ b/src/locale/locales/hu/messages.po
@@ -1116,8 +1116,8 @@ msgstr "A Bluesky egy nyílt hálózat, ahol saját szolgáltatót választhatsz
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "A Bluesky ismerősökkel még jobb!"
+msgid "Speakeasy is better with friends!"
+msgstr "A Speakeasy ismerősökkel még jobb!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/hu/messages.po
+++ b/src/locale/locales/hu/messages.po
@@ -8255,8 +8255,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Küldtünk egy új visszaigazoló emailt a(z) <0>{0}</0> címre."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Reméljük, jól érzed magad! Ne feledd; a Bluesky:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Reméljük, jól érzed magad! Ne feledd; a Speakeasy:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/id/messages.po
+++ b/src/locale/locales/id/messages.po
@@ -1301,8 +1301,8 @@ msgstr "Bluesky adalah jaringan terbuka yang memungkinkan Anda memilih penyedia 
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky lebih seru jika bersama teman!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy lebih seru jika bersama teman!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:82

--- a/src/locale/locales/id/messages.po
+++ b/src/locale/locales/id/messages.po
@@ -9455,8 +9455,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Kami telah mengirimkan email verifikasi baru ke <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Semoga Anda senang dan betah di sini. Ingat, Bluesky itu:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Semoga Anda senang dan betah di sini. Ingat, Speakeasy itu:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -7728,8 +7728,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Ti abbiamo inviato un'altra email di verifica a <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Speriamo di regalarti dei bei momenti. Ricorda, Bluesky è:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Speriamo di regalarti dei bei momenti. Ricorda, Speakeasy è:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -1056,8 +1056,8 @@ msgstr "Bluesky è una rete aperta dove puoi scegliere il fornitore di hosting. 
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky è meglio con gli amici!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy è meglio con gli amici!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -7722,8 +7722,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "別の確認コードを<0>{0}</0>へ送りました。"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "素敵なひとときをお過ごしください。覚えておいてください、Blueskyは："
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "素敵なひとときをお過ごしください。覚えておいてください、Speakeasyは："
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -1050,8 +1050,8 @@ msgstr "Bluesky は、ホスティング プロバイダーを選択できるオ
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Blueskyは友達と一緒のほうが楽しい！"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasyは友達と一緒のほうが楽しい！"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/km/messages.po
+++ b/src/locale/locales/km/messages.po
@@ -8405,8 +8405,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "យើងបានផ្ញើអ៊ីមែលផ្ទៀងផ្ទាត់មួយផ្សេងទៀតទៅ <0>{0}</0>"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "យើងសង្ឃឹមថាអ្នកមានពេលវេលាដ៏អស្ចារ្យ។ សូមចាំថា Bluesky គឺ៖"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "យើងសង្ឃឹមថាអ្នកមានពេលវេលាដ៏អស្ចារ្យ។ សូមចាំថា Speakeasy គឺ៖"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/km/messages.po
+++ b/src/locale/locales/km/messages.po
@@ -1138,8 +1138,8 @@ msgstr "Bluesky គឺជាបណ្តាញបើកចំហដែលអ្�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky គឺល្អជាមួយមិត្តភក្តិ!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy គឺល្អជាមួយមិត្តភក្តិ!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -1050,8 +1050,8 @@ msgstr "Bluesky는 호스팅 제공자를 선택할 수 있는 개방형 네트�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky는 친구와 함께하면 더 좋답니다!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy는 친구와 함께하면 더 좋답니다!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -7722,8 +7722,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "<0>{0}</0>(으)로 또 다른 인증 이메일을 보냈습니다."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "즐거운 시간 되시기 바랍니다. Bluesky의 다음 특징을 기억하세요."
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "즐거운 시간 되시기 바랍니다. Speakeasy의 다음 특징을 기억하세요."
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/ne/messages.po
+++ b/src/locale/locales/ne/messages.po
@@ -1216,7 +1216,7 @@ msgstr "ब्लूस्काई खुला नेटवर्क हो �
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
+msgid "Speakeasy is better with friends!"
 msgstr "ब्लूस्काई साथीहरूसँग अझ राम्रो छ!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80

--- a/src/locale/locales/ne/messages.po
+++ b/src/locale/locales/ne/messages.po
@@ -8852,7 +8852,7 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "हामीले अर्को प्रमाणीकरण इमेल <0>{0}</0> मा पठाएका छौं।"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
 msgstr "हामी आशा गर्छौं कि तपाईंलाई रमाइलो समय बिताउन मिलोस्। सम्झनुहोस्, ब्लूस्काई छ:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29

--- a/src/locale/locales/nl/messages.po
+++ b/src/locale/locales/nl/messages.po
@@ -7878,8 +7878,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "We hebben een nieuwe verificatie-e-mail verzonden naar <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "We hopen dat je een geweldige tijd hebt. Vergeet niet, Bluesky is:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "We hopen dat je een geweldige tijd hebt. Vergeet niet, Speakeasy is:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/nl/messages.po
+++ b/src/locale/locales/nl/messages.po
@@ -1099,8 +1099,8 @@ msgstr "Bluesky is een open netwerk waar je jouw hostingprovider kunt kiezen. Al
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky is leuker met vrienden!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy is leuker met vrienden!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/pl/messages.po
+++ b/src/locale/locales/pl/messages.po
@@ -7901,8 +7901,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Kolejny email weryfikacyjny został wysłany do <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Mamy nadzieję, że miło spędzisz czas. Pamiętaj, że Bluesky jest:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Mamy nadzieję, że miło spędzisz czas. Pamiętaj, że Speakeasy jest:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/pl/messages.po
+++ b/src/locale/locales/pl/messages.po
@@ -1097,8 +1097,8 @@ msgstr "Bluesky to otwarta sieć, w której możesz wybrać swojego dostawcę ho
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky jest lepszy ze znajomymi!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy jest lepszy ze znajomymi!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -9444,8 +9444,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Enviamos outro e-mail de verificação para <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Esperamos que você se divirta. Lembre-se, o Bluesky é:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Esperamos que você se divirta. Lembre-se, o Speakeasy é:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -1296,8 +1296,8 @@ msgstr "Bluesky é uma rede aberta onde você pode escolher seu provedor de hosp
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky é melhor com amigos!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy é melhor com amigos!"
 
 #: src/components/dialogs/nuxs/TenMillion/Trigger.tsx:43
 #: src/components/dialogs/nuxs/TenMillion/Trigger.tsx:59

--- a/src/locale/locales/ro/messages.po
+++ b/src/locale/locales/ro/messages.po
@@ -8405,8 +8405,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Am trimis un alt e-mail de verificare către <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Sperăm să ai un timp minunat. Amintește-ți, Bluesky este:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Sperăm să ai un timp minunat. Amintește-ți, Speakeasy este:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/ro/messages.po
+++ b/src/locale/locales/ro/messages.po
@@ -1138,8 +1138,8 @@ msgstr "Bluesky este o rețea deschisă unde poți alege furnizorul de găzduire
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky este mai bun cu prietenii!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy este mai bun cu prietenii!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -1058,8 +1058,8 @@ msgstr "Bluesky - это открытая сеть, где вы можете в�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky лучше с друзьями!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy лучше с друзьями!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -7762,8 +7762,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Мы повторно отправили письмо с подтверждением на <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Мы надеемся, что вы отлично проведёте время. Помните, Bluesky - это:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Мы надеемся, что вы отлично проведёте время. Помните, Speakeasy - это:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/th/messages.po
+++ b/src/locale/locales/th/messages.po
@@ -9442,8 +9442,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "เราได้ส่งอีเมลยืนยันอีกฉบับไปยัง <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "เราหวังว่าคุณจะมีช่วงเวลาที่ดีเยี่ยม จำไว้ว่า Bluesky คือ:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "เราหวังว่าคุณจะมีช่วงเวลาที่ดีเยี่ยม จำไว้ว่า Speakeasy คือ:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/th/messages.po
+++ b/src/locale/locales/th/messages.po
@@ -1296,8 +1296,8 @@ msgstr "Bluesky เป็นเครือข่ายเปิดที่ค�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky สนุกยิ่งขึ้นเมื่อมีเพื่อน!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy สนุกยิ่งขึ้นเมื่อมีเพื่อน!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:82

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -1358,8 +1358,8 @@ msgstr "Bluesky, barındırma sağlayıcınızı seçebileceğiniz açık bir a�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky arkadaşlarla daha güzel!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy arkadaşlarla daha güzel!"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:82

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -9957,8 +9957,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "<0>{0}</0> adresine başka bir doğrulama e-postası gönderdik."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Harika vakit geçirmenizi umuyoruz. Unutmayın, Bluesky:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Harika vakit geçirmenizi umuyoruz. Unutmayın, Speakeasy:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/uk/messages.po
+++ b/src/locale/locales/uk/messages.po
@@ -1301,7 +1301,7 @@ msgstr ""
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
+msgid "Speakeasy is better with friends!"
 msgstr ""
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80

--- a/src/locale/locales/uk/messages.po
+++ b/src/locale/locales/uk/messages.po
@@ -9455,8 +9455,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr ""
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Ми сподіваємося, що ви проведете чудово свій час. Пам'ятайте, Bluesky — це:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Ми сподіваємося, що ви проведете чудово свій час. Пам'ятайте, Speakeasy — це:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/vi/messages.po
+++ b/src/locale/locales/vi/messages.po
@@ -7869,8 +7869,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "Chúng tôi đã gởi một email xác minh khác đến <0>{0}</0>."
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "Chúng tôi mong bạn có một trải nghiệm tuyệt vời. Hãy nhớ rằng, Bluesky là:"
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "Chúng tôi mong bạn có một trải nghiệm tuyệt vời. Hãy nhớ rằng, Speakeasy là:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/vi/messages.po
+++ b/src/locale/locales/vi/messages.po
@@ -1097,8 +1097,8 @@ msgstr "Bluesky là mạng mở nơi bạn có thể chọn nhà cung cấp dị
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky cùng bạn bè sẽ vui hơn!"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy cùng bạn bè sẽ vui hơn!"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -7727,8 +7727,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "我们将发送另一封验证邮件至 <0>{0}</0>。"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "我们希望你在此度过愉快的时光。请记住，Bluesky 是："
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "我们希望你在此度过愉快的时光。请记住，Speakeasy 是："
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -1055,8 +1055,8 @@ msgstr "Bluesky 是一个开放的社交网络，你可以自由选择托管服�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "与天友们一起，Bluesky 更美好！"
+msgid "Speakeasy is better with friends!"
+msgstr "与天友们一起，Speakeasy 更美好！"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -7729,8 +7729,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "我哋傳送咗另一封驗證電郵去到 <0>{0}</0> 度。"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "我哋希望你玩得開心。唔好忘記，Bluesky 係："
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "我哋希望你玩得開心。唔好忘記，Speakeasy 係："
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -1055,8 +1055,8 @@ msgstr "Bluesky 係一個開放嘅網絡，你可以喺嗰度揀你嘅託管服�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky 係要同多啲天友玩先正！"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy 係要同多啲天友玩先正！"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -1055,8 +1055,8 @@ msgstr "Bluesky 是一個開放的網路，您可以自行挑選託管服務提�
 
 #: src/components/ProgressGuide/List.tsx:53
 #: src/components/ProgressGuide/List.tsx:70
-msgid "Bluesky is better with friends!"
-msgstr "Bluesky 因朋友而更好！"
+msgid "Speakeasy is better with friends!"
+msgstr "Speakeasy 因朋友而更好！"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -7727,8 +7727,8 @@ msgid "We have sent another verification email to <0>{0}</0>."
 msgstr "我們已傳送另一封驗證電子郵件至 <0>{0}</0>。"
 
 #: src/screens/Onboarding/StepFinished.tsx:238
-msgid "We hope you have a wonderful time. Remember, Bluesky is:"
-msgstr "我們希望您在這裡度過愉快的時光。請記住，Bluesky 是："
+msgid "We hope you have a wonderful time. Remember, Speakeasy is:"
+msgstr "我們希望您在這裡度過愉快的時光。請記住，Speakeasy 是："
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -235,7 +235,9 @@ export function StepFinished() {
         <Trans>You're ready to go!</Trans>
       </TitleText>
       <DescriptionText>
-        <Trans>We hope you have a wonderful time. Remember, Bluesky is:</Trans>
+        <Trans>
+          We hope you have a wonderful time. Remember, Speakeasy is:
+        </Trans>
       </DescriptionText>
 
       <View style={[a.pt_5xl, a.gap_3xl]}>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -25,8 +25,8 @@ export const Policies = ({
     return <View />
   }
 
-  const tos = validWebLink(serviceDescription.links?.termsOfService)
-  const pp = validWebLink(serviceDescription.links?.privacyPolicy)
+  const tos = validWebLink('https://about.spkeasy.social/terms')
+  const pp = validWebLink('https://about.spkeasy.social/privacy')
 
   if (!tos && !pp) {
     return (

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -621,12 +621,12 @@ function ExtraLinks() {
       <InlineLinkText
         style={[a.text_md]}
         label={_(msg`Terms of Service`)}
-        to="https://bsky.social/about/support/tos">
+        to="https://about.spkeasy.social/terms">
         <Trans>Terms of Service</Trans>
       </InlineLinkText>
       <InlineLinkText
         style={[a.text_md]}
-        to="https://bsky.social/about/support/privacy-policy"
+        to="https://about.spkeasy.social/privacy"
         label={_(msg`Privacy Policy`)}>
         <Trans>Privacy Policy</Trans>
       </InlineLinkText>


### PR DESCRIPTION
Fixes a few issues with blue sky being referenced in the code.

I assume the links in the signup should point to speakeasy? Even though they're creating an account in Bluesky?