### PR TITLE
Performance improvement

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -28,6 +28,7 @@ import {Provider as A11yProvider} from '#/state/a11y'
 import {Provider as MutedThreadsProvider} from '#/state/cache/thread-mutes'
 import {Provider as DialogStateProvider} from '#/state/dialogs'
 import {listenSessionDropped} from '#/state/events'
+import {usePrefetchFollowers} from '#/state/followers-cache'
 import {
   beginResolveGeolocation,
   ensureGeolocationResolved,
@@ -95,6 +96,8 @@ function InnerApp() {
   const {_} = useLingui()
 
   const hasCheckedReferrer = useStarterPackEntry()
+
+  usePrefetchFollowers()
 
   // init
   useEffect(() => {

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -61,6 +61,7 @@ import {Provider as LoggedOutViewProvider} from '#/state/shell/logged-out'
 import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
+import {useSpeakeasyPreAuth} from '#/state/speakeasy-pre-auth'
 import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
 import {Provider as TrendingConfigProvider} from '#/state/trending-config'
 import {TestCtrls} from '#/view/com/testing/TestCtrls'
@@ -102,6 +103,7 @@ function InnerApp() {
   const agent = useAgent()
 
   usePrefetchFollowers()
+  useSpeakeasyPreAuth()
 
   // Prefetch private key
   useEffect(() => {

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -51,6 +51,7 @@ import {Provider as LoggedOutViewProvider} from '#/state/shell/logged-out'
 import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
+import {useSpeakeasyPreAuth} from '#/state/speakeasy-pre-auth'
 import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
 import {Provider as TrendingConfigProvider} from '#/state/trending-config'
 import {Provider as ActiveVideoProvider} from '#/view/com/util/post-embeds/ActiveVideoWebContext'
@@ -81,6 +82,7 @@ function InnerApp() {
   const agent = useAgent()
 
   usePrefetchFollowers()
+  useSpeakeasyPreAuth()
 
   // Prefetch private key
   useEffect(() => {

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -18,6 +18,7 @@ import {Provider as A11yProvider} from '#/state/a11y'
 import {Provider as MutedThreadsProvider} from '#/state/cache/thread-mutes'
 import {Provider as DialogStateProvider} from '#/state/dialogs'
 import {listenSessionDropped} from '#/state/events'
+import {usePrefetchFollowers} from '#/state/followers-cache'
 import {
   beginResolveGeolocation,
   ensureGeolocationResolved,
@@ -74,6 +75,8 @@ function InnerApp() {
   const theme = useColorModeTheme()
   const {_} = useLingui()
   const hasCheckedReferrer = useStarterPackEntry()
+
+  usePrefetchFollowers()
 
   // init
   useEffect(() => {

--- a/src/lib/api/feed/private-posts.ts
+++ b/src/lib/api/feed/private-posts.ts
@@ -2,7 +2,7 @@ import {AppBskyFeedDefs, BskyAgent} from '@atproto/api'
 
 import {getBaseCdnUrl} from '#/lib/api/feed/utils'
 import {callSpeakeasyApiWithAgent} from '#/lib/api/speakeasy'
-import {getPrivateKey} from '#/lib/api/user-keys'
+import {getCachedPrivateKey} from '#/lib/api/user-keys'
 import {decryptContent, decryptDEK} from '#/lib/encryption'
 import {getCachedFollowerDids} from '#/state/followers-cache'
 import {transformPrivateEmbed} from '#/state/queries/post-feed'
@@ -83,8 +83,9 @@ export class PrivatePostsFeedAPI implements FeedAPI {
         })
       }
 
-      const privateKey = await getPrivateKey(options =>
-        callSpeakeasyApiWithAgent(this.agent, options),
+      const privateKey = await getCachedPrivateKey(
+        this.agent.session!.did,
+        options => callSpeakeasyApiWithAgent(this.agent, options),
       )
 
       const posts = (

--- a/src/lib/api/feed/private-posts.ts
+++ b/src/lib/api/feed/private-posts.ts
@@ -4,6 +4,7 @@ import {getBaseCdnUrl} from '#/lib/api/feed/utils'
 import {callSpeakeasyApiWithAgent} from '#/lib/api/speakeasy'
 import {getPrivateKey} from '#/lib/api/user-keys'
 import {decryptContent, decryptDEK} from '#/lib/encryption'
+import {getCachedFollowerDids} from '#/state/followers-cache'
 import {transformPrivateEmbed} from '#/state/queries/post-feed'
 import {FeedAPI, FeedAPIResponse} from './types'
 
@@ -42,15 +43,12 @@ export class PrivatePostsFeedAPI implements FeedAPI {
 
       const query: {
         limit: string
-        audience: string
         cursor?: string
         filter?: string
       } = {
         limit: limit.toString(),
-        audience: audience || 'trusted',
       }
       if (cursor) query.cursor = cursor
-      if (audience === 'following') query.filter = 'follows'
 
       const data = await callSpeakeasyApiWithAgent(this.agent, {
         api: 'social.spkeasy.privatePost.getPosts',
@@ -70,13 +68,28 @@ export class PrivatePostsFeedAPI implements FeedAPI {
         }[]
       } = data
 
+      let filteredPosts = encryptedPosts
+
+      if (audience === 'following') {
+        const followerDids = await getCachedFollowerDids()
+
+        // It's too slow to filter on the server as we have to wait
+        // for the server to compile the followers list.
+        // So we compile it when the app first loads, and then
+        // filter the private posts client side.
+        // Eventually we'll fix this with a proper AppView.
+        filteredPosts = encryptedPosts.filter(post => {
+          return followerDids.includes(post.authorDid)
+        })
+      }
+
       const privateKey = await getPrivateKey(options =>
         callSpeakeasyApiWithAgent(this.agent, options),
       )
 
       const posts = (
         await Promise.all(
-          encryptedPosts.map(async (encryptedPost: any) => {
+          filteredPosts.map(async (encryptedPost: any) => {
             const encryptedDek = encryptedSessionKeys.find(
               key => key.sessionId === encryptedPost.sessionId,
             )?.encryptedDek

--- a/src/lib/api/user-keys.ts
+++ b/src/lib/api/user-keys.ts
@@ -3,6 +3,11 @@ import {chunk} from 'lodash'
 import {generateKeyPair} from '#/lib/encryption'
 import {getErrorCode, SpeakeasyApiCall} from './speakeasy'
 
+let cachedPrivateKeyPromise:
+  | Promise<{privateKey: string; userKeyPairId: string}>
+  | undefined
+let cachedPrivateKeyUserDid: string | undefined
+
 /**
  * Retrieves the encrypted session key from the Speakeasy API.
  * @param {SpeakeasyApi} speakeasyApi - The Speakeasy API client instance
@@ -67,6 +72,25 @@ export async function getPublicKeys(
   }
 
   return allPublicKeys
+}
+
+/**
+ * Retrieves and caches the private key for a given user DID.
+ * @param {string} userDid - The DID of the user
+ * @param {SpeakeasyApi} speakeasyApi - The Speakeasy API client instance
+ * @returns {Promise<{privateKey: string, userKeyPairId: string}>} The cached private key
+ */
+export async function getCachedPrivateKey(
+  userDid: string,
+  speakeasyApi: SpeakeasyApiCall,
+) {
+  if (cachedPrivateKeyUserDid === userDid && cachedPrivateKeyPromise) {
+    return cachedPrivateKeyPromise
+  }
+
+  cachedPrivateKeyUserDid = userDid
+  cachedPrivateKeyPromise = getPrivateKey(speakeasyApi)
+  return cachedPrivateKeyPromise
 }
 
 /**

--- a/src/state/followers-cache.tsx
+++ b/src/state/followers-cache.tsx
@@ -1,0 +1,109 @@
+import {useEffect} from 'react'
+import {AppBskyGraphGetFollows} from '@atproto/api'
+
+import {logger} from '#/logger'
+import {useAgent, useSession} from '#/state/session'
+
+// In-memory cache of follower DIDs
+let cachedFollowerDids: string[] = []
+let isFetching = false
+let hasFetched = false
+let lastAccountDid: string | undefined
+let retryCount = 0
+const MAX_RETRIES = 3
+let cachedFollowerDidsPromise: Promise<string[]>
+
+export async function getCachedFollowerDids() {
+  return cachedFollowerDidsPromise
+}
+
+export function removeCachedFollowerDid(did: string) {
+  // Update cache
+  const index = cachedFollowerDids.indexOf(did)
+  if (index !== -1) {
+    cachedFollowerDids.splice(index, 1)
+  }
+}
+
+export function addCachedFollowerDid(did: string) {
+  if (!cachedFollowerDids.includes(did)) {
+    cachedFollowerDids.push(did)
+  }
+}
+
+export function usePrefetchFollowers() {
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+
+  useEffect(() => {
+    // Reset if account changed
+    if (currentAccount?.did !== lastAccountDid) {
+      hasFetched = false
+      retryCount = 0
+      lastAccountDid = currentAccount?.did
+    }
+
+    console.log('usePrefetchFollowers', {
+      currentAccount,
+      hasFetched,
+      isFetching,
+    })
+
+    if (!currentAccount?.did || hasFetched || isFetching) return
+
+    hasFetched = true
+    isFetching = true
+
+    async function fetchAllFollowers() {
+      let allFollowDids: string[] = [currentAccount!.did]
+      let cursor: string | undefined
+
+      console.log('prefetching followers')
+
+      try {
+        do {
+          const res = await agent.api.app.bsky.graph.getFollows({
+            actor: currentAccount!.did,
+            limit: 100,
+            ...(cursor ? {cursor} : {}),
+          })
+
+          const data = res.data as AppBskyGraphGetFollows.OutputSchema
+          const followDids = data.follows.map(follow => follow.did)
+          allFollowDids.push(...followDids)
+          cursor = data.cursor
+        } while (cursor)
+
+        cachedFollowerDids = allFollowDids
+        logger.debug('Successfully cached follower DIDs', {
+          count: allFollowDids.length,
+        })
+      } catch (error) {
+        // If we encounter any error, cache what we have so far
+        cachedFollowerDids = allFollowDids
+        logger.error('Error prefetching followers:', {error})
+
+        // Retry with exponential backoff if we haven't exceeded max retries
+        if (retryCount < MAX_RETRIES) {
+          retryCount++
+          const backoffTime = Math.pow(2, retryCount) * 2000 // 4s, 8s, 16s
+          logger.debug('Retrying follower fetch', {
+            attempt: retryCount,
+            backoffTime,
+          })
+
+          setTimeout(() => {
+            hasFetched = false
+            isFetching = false
+          }, backoffTime)
+        }
+      } finally {
+        console.log('fetchAllFollowers done')
+        isFetching = false
+        return cachedFollowerDids
+      }
+    }
+
+    cachedFollowerDidsPromise = fetchAllFollowers()
+  }, [currentAccount, agent])
+}

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -21,6 +21,10 @@ import {until} from '#/lib/async/until'
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
 import {logEvent, LogEvents, toClout} from '#/lib/statsig/statsig'
 import {Shadow} from '#/state/cache/types'
+import {
+  addCachedFollowerDid,
+  removeCachedFollowerDid,
+} from '#/state/followers-cache'
 import {STALE} from '#/state/queries'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import * as userActionHistory from '#/state/userActionHistory'
@@ -239,6 +243,7 @@ export function useProfileFollowMutationQueue(
           did,
         })
         userActionHistory.follow([did])
+        addCachedFollowerDid(did)
         return uri
       } else {
         if (prevFollowingUri) {
@@ -248,6 +253,7 @@ export function useProfileFollowMutationQueue(
           })
           userActionHistory.unfollow([did])
         }
+        removeCachedFollowerDid(did)
         return undefined
       }
     },
@@ -316,7 +322,9 @@ function useProfileFollowMutation(
         followeeClout: toClout(profile.followersCount),
         followerClout: toClout(ownProfile?.followersCount),
       })
-      return await agent.follow(did)
+      const result = await agent.follow(did)
+      addCachedFollowerDid(did)
+      return result
     },
   })
 }

--- a/src/state/speakeasy-pre-auth.tsx
+++ b/src/state/speakeasy-pre-auth.tsx
@@ -1,0 +1,25 @@
+import {useEffect} from 'react'
+
+import {callSpeakeasyApiWithAgent} from '#/lib/api/speakeasy'
+import {useAgent} from '#/state/session'
+
+export function useSpeakeasyPreAuth() {
+  const agent = useAgent()
+  const did = agent.did
+
+  useEffect(() => {
+    if (!did) return
+
+    // Send pre-auth request. This enables Speakeasy to briefly cache the
+    // session authorisation and subsequent initial requests for
+    // private posts, etc. will be faster.
+    callSpeakeasyApiWithAgent(agent, {
+      api: 'social.spkeasy.privatePost.preAuth',
+    }).catch(error => {
+      // Only log if it's not a NotFoundError (which is expected for new users)
+      if (error.error !== 'NotFoundError') {
+        console.error('Failed to pre-auth with Speakeasy:', error)
+      }
+    })
+  }, [did, agent])
+}


### PR DESCRIPTION
Feed was quite slow on initial load (3 to 5 seconds)

This improves it quite a bit by:
* Pre-fetches the follower DID's on the client and then uses those to filter private posts, rather than the server doing it which was much slower as we had to wait for the server to make many requests to Bluesky before it could respond
* Earlier fetching of the private key for decoding private posts
* Immediately on load sends a request to social.spkeasy.privatePost.preAuth which causes it to cache the session for 5 minutes so that the initial request to load the feed doesn't have to wait for the server to check the validity of the session with Bluesky

Longer term, the getPosts lag should be done server side with a proper AppView