### PR TITLE
PrivatePostPill component + refactor of PostMeta to include component

### DIFF
--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -11,8 +11,8 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {niceDate} from '#/lib/strings/time'
 import {isAndroid} from '#/platform/detection'
 import {precacheProfile} from '#/state/queries/profile'
+import {PrivatePostPill} from '#/view/com/util/PrivatePostPill'
 import {atoms as a, useTheme, web} from '#/alf'
-import {Lock_Stroke2_Corner0_Rounded as LockIcon} from '#/components/icons/Lock'
 import {WebOnlyInlineLinkText} from '#/components/Link'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {Text} from '#/components/Typography'
@@ -120,15 +120,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         )}
       </TimeElapsed>
 
-      {opts.isPrivate && (
-        <LockIcon
-          style={{color: t.atoms.text_contrast_medium.color}}
-          width={14}
-          height={14}
-          title={_(msg`Private post`)}
-          aria-label={_(msg`Private post`)}
-        />
-      )}
+      {opts.isPrivate && <PrivatePostPill />}
     </View>
   )
 }

--- a/src/view/com/util/PrivatePostPill.tsx
+++ b/src/view/com/util/PrivatePostPill.tsx
@@ -6,11 +6,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {Lock_Stroke2_Corner0_Rounded as LockIcon} from '#/components/icons/Lock'
 import {Text} from '#/components/Typography'
 
-interface PrivatePostPillProps {
-  noBg?: boolean
-}
-
-export function PrivatePostPill({noBg = false}: PrivatePostPillProps) {
+export function PrivatePostPill() {
   const t = useTheme()
   const {_} = useLingui()
 
@@ -20,7 +16,7 @@ export function PrivatePostPill({noBg = false}: PrivatePostPillProps) {
         a.flex_row,
         a.align_center,
         a.rounded_xs,
-        !noBg && t.atoms.bg_contrast_50,
+        t.atoms.bg_contrast_50,
         t.atoms.border_contrast_medium,
         {gap: 3},
         {paddingLeft: 4, paddingRight: 3, paddingVertical: 3},

--- a/src/view/com/util/PrivatePostPill.tsx
+++ b/src/view/com/util/PrivatePostPill.tsx
@@ -1,0 +1,47 @@
+import {View} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Lock_Stroke2_Corner0_Rounded as LockIcon} from '#/components/icons/Lock'
+import {Text} from '#/components/Typography'
+
+interface PrivatePostPillProps {
+  noBg?: boolean
+}
+
+export function PrivatePostPill({noBg = false}: PrivatePostPillProps) {
+  const t = useTheme()
+  const {_} = useLingui()
+
+  return (
+    <View
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.rounded_xs,
+        !noBg && t.atoms.bg_contrast_50,
+        t.atoms.border_contrast_medium,
+        {gap: 3},
+        {paddingLeft: 4, paddingRight: 3, paddingVertical: 3},
+      ]}>
+      <LockIcon
+        style={{color: t.atoms.text_contrast_medium.color}}
+        width={12}
+        height={12}
+        title={_(msg`Private post`)}
+        aria-label={_(msg`Private post`)}
+      />
+      <Text
+        style={[
+          a.text_xs,
+          a.font_bold,
+          a.leading_tight,
+          t.atoms.text_contrast_medium,
+          {paddingRight: 3},
+        ]}>
+        {_(msg`Private Post`)}
+      </Text>
+    </View>
+  )
+}


### PR DESCRIPTION

**🤓 What should we check?**
- PrivatePostPill component code looks ok?
- Any other instances where this component would be used apart from PostMeta?

**💫 What have you changed?**
- Created PrivatePostPill component
- Refactored PostMeta to use PrivatePostPill component for private posts

**🎟️ Which issue does this solve?**
- Making private posts more prominent

**🧪 How can this be tested or verified?**
- Create a private post

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
<img width="499" alt="image" src="https://github.com/user-attachments/assets/b64927cc-9177-4fcb-9cf1-853433657f00" />

</details>