### PR TITLE
[Test] - Fix type errors for LeftNav

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -373,7 +373,9 @@ function NavItem({
         a.transition_color,
       ]}
       hoverStyle={t.atoms.bg_contrast_25}
+      // @ts-ignore the function signature differs on web -prf
       onPress={onPressWrapped}
+      // @ts-ignore web only -prf
       href={href}
       dataSet={{noUnderline: 1}}
       role="link"


### PR DESCRIPTION
**🤓 What should we check?**
- Do the TS ignore comments make sense

**💫 What have you changed?**
I took a look at the [history of the component file](https://github.com/speakeasy-social/speakeasy/commit/c4cff83d9cb36208e251d75a52fa4adcef8c0126#diff-8f41ee67a711f16b2efba4087d921ecb788c227bc3e9059e5fddb4f9a63c3f58L355) and realised that these two attributes had originally included typescript ignore comments. So I just added them back to fix the type errors.

**🎟️ Which issue does this solve?**
- This PR resolves 

**🧪 How can this be tested or verified?**
- On your desktop, try to interact with the Left Navigation menu. Click on the various items to ensure clicking works.
