### PR TITLE
[Fix] - Ensure the Bluesky button uses their brand colour

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -33,6 +33,7 @@ export type ButtonColor =
   | 'gradient_sunset'
   | 'gradient_nordic'
   | 'gradient_bonfire'
+  | 'bluesky'
 export type ButtonSize = 'tiny' | 'small' | 'large'
 export type ButtonShape = 'round' | 'square' | 'default'
 export type VariantProps = {
@@ -245,6 +246,45 @@ export const Button = React.forwardRef<View, ButtonProps>(
             })
           }
         }
+      } else if (color === 'bluesky') {
+        if (variant === 'solid') {
+          if (!disabled) {
+            baseStyles.push({
+              backgroundColor: '#0066FF',
+            })
+            hoverStyles.push({
+              backgroundColor: '#0052CC',
+            })
+          } else {
+            baseStyles.push({
+              backgroundColor: '#99B3FF',
+            })
+          }
+        } else if (variant === 'outline') {
+          baseStyles.push(a.border, t.atoms.bg, {
+            borderWidth: 1,
+          })
+
+          if (!disabled) {
+            baseStyles.push(a.border, {
+              borderColor: '#0066FF',
+            })
+            hoverStyles.push(a.border, {
+              backgroundColor: '#E6F0FF',
+            })
+          } else {
+            baseStyles.push(a.border, {
+              borderColor: '#99B3FF',
+            })
+          }
+        } else if (variant === 'ghost') {
+          if (!disabled) {
+            baseStyles.push(t.atoms.bg)
+            hoverStyles.push({
+              backgroundColor: '#E6F0FF',
+            })
+          }
+        }
       } else if (color === 'secondary') {
         if (variant === 'solid') {
           if (!disabled) {
@@ -432,6 +472,7 @@ export const Button = React.forwardRef<View, ButtonProps>(
         gradient_sunset: tokens.gradients.sunset,
         gradient_nordic: tokens.gradients.nordic,
         gradient_bonfire: tokens.gradients.bonfire,
+        bluesky: tokens.gradients.sky,
       }[color || 'primary']
 
       if (variant === 'gradient') {
@@ -643,6 +684,26 @@ export function useSharedButtonTextStyles() {
           baseStyles.push({color: t.palette.negative_400})
         } else {
           baseStyles.push({color: t.palette.negative_400, opacity: 0.5})
+        }
+      }
+    } else if (color === 'bluesky') {
+      if (variant === 'solid' || variant === 'gradient') {
+        if (!disabled) {
+          baseStyles.push({color: '#FFFFFF'})
+        } else {
+          baseStyles.push({color: '#FFFFFF', opacity: 0.5})
+        }
+      } else if (variant === 'outline') {
+        if (!disabled) {
+          baseStyles.push({color: '#0066FF'})
+        } else {
+          baseStyles.push({color: '#99B3FF'})
+        }
+      } else if (variant === 'ghost') {
+        if (!disabled) {
+          baseStyles.push({color: '#0066FF'})
+        } else {
+          baseStyles.push({color: '#99B3FF'})
         }
       }
     } else {

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -164,7 +164,7 @@ export const SplashScreen = ({
                 )}
                 size="large"
                 variant="solid"
-                color="primary">
+                color="bluesky">
                 <ButtonText>
                   <Trans>Create a Bluesky account</Trans>
                 </ButtonText>


### PR DESCRIPTION
**🤓 What should we check?**
- Are you able to see the blue button shown in the expected results screenshot, below?
- Are the code updates missing anything?

**💫 What have you changed?**
- I reinstated the logic that was specific to the `bluesky` colour and included it in type definitions so that type errors were not created

**🎟️ Which issue does this solve?**
- This PR fixes issues that arose from work in https://github.com/speakeasy-social/speakeasy/pull/69 

**🧪 How can this be tested or verified?**
- Spin up the app
- Click on `Create account` button
- See if the `Create a Bluesky account` is the correct blue colour

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
    <img width="500" src="https://github.com/user-attachments/assets/323ff650-378c-4eae-984e-a00df89f29df" />
</details>