### PR TITLE
Feature/private reply notifications

### DIFF
--- a/src/lib/api/feed/private-posts.ts
+++ b/src/lib/api/feed/private-posts.ts
@@ -705,12 +705,16 @@ export function formatPostView(
             root: {
               uri: post.reply.root.uri,
               // FIXME, should be the post's cid, but any valid cid will do
-              cid: 'bafyreichsn5zvtlqksg6ojq3ih2yx646mzwhvopejmefat7m5f5fdlvgdi',
+              cid:
+                post.reply.root.uri &&
+                'bafyreichsn5zvtlqksg6ojq3ih2yx646mzwhvopejmefat7m5f5fdlvgdi',
             },
             parent: {
               uri: post.reply.parent.uri,
               // FIXME, should be the post's cid, but any valid cid will do
-              cid: 'bafyreichsn5zvtlqksg6ojq3ih2yx646mzwhvopejmefat7m5f5fdlvgdi',
+              cid:
+                post.reply.parent.uri &&
+                'bafyreichsn5zvtlqksg6ojq3ih2yx646mzwhvopejmefat7m5f5fdlvgdi',
             },
           }
         : undefined,

--- a/src/lib/api/feed/private-posts.ts
+++ b/src/lib/api/feed/private-posts.ts
@@ -715,9 +715,10 @@ export function formatPostView(
           }
         : undefined,
     },
-    embed: post.embed
-      ? transformPrivateEmbed(post.embed, post.authorDid, baseUrl, quotedPost)
-      : undefined,
+    embed:
+      baseUrl && post.embed
+        ? transformPrivateEmbed(post.embed, post.authorDid, baseUrl, quotedPost)
+        : undefined,
     replyCount: 0,
     repostCount: 0,
     likeCount: 0,

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -280,11 +280,11 @@ async function resolveReply(
     const encryptedPost = encryptedPosts.encryptedPosts[0]
     return {
       root: {
-        uri: encryptedPost.uri,
+        uri: encryptedPost.reply?.root.uri || encryptedPost.uri,
         cid: 'fixme-calculate-cid',
       },
       parent: {
-        uri: encryptedPost.reply?.root.uri || encryptedPost.uri,
+        uri: encryptedPost.uri,
         cid: 'fixme-calculate-cid',
       },
     }

--- a/src/lib/api/private-notifications.ts
+++ b/src/lib/api/private-notifications.ts
@@ -1,6 +1,10 @@
 import {AppBskyNotificationListNotifications, BskyAgent} from '@atproto/api'
 
-import {fetchProfiles, profileToAuthorView} from '#/lib/api/feed/private-posts'
+import {
+  EncryptedPost,
+  fetchProfiles,
+  profileToAuthorView,
+} from '#/lib/api/feed/private-posts'
 import {callSpeakeasyApiWithAgent} from '#/lib/api/speakeasy'
 
 export type PrivateNotification = {
@@ -17,6 +21,7 @@ export type PrivateNotification = {
   record: any
 
   author: AppBskyNotificationListNotifications.Notification['author']
+  post?: EncryptedPost
 }
 
 type PrivateNotificationResponse = {

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -329,16 +329,42 @@ function getSubjectUri(
 function formatPrivateNotification(
   notif: PrivateNotification,
 ): AppBskyNotificationListNotifications.Notification {
+  let formattedNotification
+
+  if (notif.reason === 'reply') {
+    formattedNotification = {
+      ...notif,
+      uri: notif.post?.uri || 'at://undefined',
+      record: {
+        $type: `app.bsky.feed.post`,
+        reply: {
+          root: {
+            uri: notif.post?.reply?.root.uri,
+          },
+          parent: {
+            uri: notif.post?.reply?.parent.uri,
+          },
+        },
+        createdAt: notif.post?.createdAt,
+      },
+    }
+  } else if (notif.reason === 'like') {
+    formattedNotification = {
+      ...notif,
+      uri: `at://${notif.author.did}/social.spkeasy.feed.like/${notif.createdAt}`,
+      record: {
+        $type: `app.bsky.feed.like`,
+        subject: {
+          uri: notif.reasonSubject,
+          validationStatus: 'valid',
+        },
+      },
+    }
+  }
+
   return {
     ...notif,
-    //      uri: `at://${notif.author.did}/social.spkeasy.feed.like/${notif.createdAt}`,
-    record: {
-      $type: 'app.bsky.feed.like',
-      subject: {
-        uri: notif.reasonSubject,
-        validationStatus: 'valid',
-      },
-    },
     isPrivate: true,
+    ...formattedNotification,
   }
 }

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -168,6 +168,7 @@ let NotificationFeedItem = ({
             }
           }
           hideTopBorder={hideTopBorder}
+          hasReply={item.type === 'reply'}
         />
       </Link>
     )

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -36,6 +36,7 @@ import {forceLTR} from '#/lib/strings/bidi'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {niceDate} from '#/lib/strings/time'
+import {postUriToRelativePath} from '#/lib/strings/url-helpers'
 import {colors, s} from '#/lib/styles'
 import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
@@ -95,14 +96,12 @@ let NotificationFeedItem = ({
   const itemHref = useMemo(() => {
     if (item.type === 'post-like' || item.type === 'repost') {
       if (item.subjectUri) {
-        const urip = new AtUri(item.subjectUri)
-        return `/profile/${urip.host}/post/${urip.rkey}`
+        return postUriToRelativePath(item.subjectUri) || ''
       }
     } else if (item.type === 'follow') {
       return makeProfileLink(item.notification.author)
     } else if (item.type === 'reply') {
-      const urip = new AtUri(item.notification.uri)
-      return `/profile/${urip.host}/post/${urip.rkey}`
+      return postUriToRelativePath(item.notification.uri) || ''
     } else if (
       item.type === 'feedgen-like' ||
       item.type === 'starterpack-joined'

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -118,7 +118,13 @@ function PostInner({
     () => countLines(richText?.text) >= MAX_POST_LINES,
   )
   const itemUrip = new AtUri(post.uri)
-  const itemHref = makeProfileLink(post.author, 'post', itemUrip.rkey)
+  const isPrivatePost =
+    post.$type === 'social.spkeasy.feed.defs#privatePostView'
+  const itemHref = makeProfileLink(
+    post.author,
+    isPrivatePost ? 'private-post' : 'post',
+    itemUrip.rkey,
+  )
   let replyAuthorDid = ''
   if (record.reply) {
     const urip = new AtUri(record.reply.parent?.uri || record.reply.root.uri)

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -101,6 +101,7 @@ function PostInner({
   showReplyLine,
   hideTopBorder,
   style,
+  hasReply,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
@@ -109,6 +110,7 @@ function PostInner({
   showReplyLine?: boolean
   hideTopBorder?: boolean
   style?: StyleProp<ViewStyle>
+  hasReply?: boolean
 }) {
   const queryClient = useQueryClient()
   const pal = usePalette('default')
@@ -155,6 +157,8 @@ function PostInner({
   const {currentAccount} = useSession()
   const isMe = replyAuthorDid === currentAccount?.did
 
+  const isPrivate = post.$type === 'social.spkeasy.feed.defs#privatePostView'
+  const replyLabel = isPrivate ? 'Private reply' : 'Reply'
   const [hover, setHover] = React.useState(false)
   return (
     <Link
@@ -192,7 +196,7 @@ function PostInner({
             timestamp={post.indexedAt}
             postHref={itemHref}
           />
-          {replyAuthorDid !== '' && (
+          {hasReply && (
             <View style={[s.flexRow, s.mb2, s.alignCenter]}>
               <FontAwesomeIcon
                 icon="reply"
@@ -205,10 +209,12 @@ function PostInner({
                 lineHeight={1.2}
                 numberOfLines={1}>
                 {isMe ? (
-                  <Trans context="description">Reply to you</Trans>
+                  <Trans context="description">{replyLabel} to you</Trans>
+                ) : replyAuthorDid === '' ? (
+                  <Trans context="description">{replyLabel} to post</Trans>
                 ) : (
                   <Trans context="description">
-                    Reply to{' '}
+                    {replyLabel} to{' '}
                     <ProfileHoverCard inline did={replyAuthorDid}>
                       <UserInfoText
                         type="sm"

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -423,6 +423,7 @@ let FeedItemInner = ({
                 blocked={isParentBlocked}
                 notFound={isParentNotFound}
                 profile={parentAuthor}
+                post={post}
               />
             )}
           <LabelsOnMyPost post={post} />
@@ -576,27 +577,32 @@ function ReplyToLabel({
   profile,
   blocked,
   notFound,
+  post,
 }: {
   profile: AppBskyActorDefs.ProfileViewBasic | undefined
   blocked?: boolean
   notFound?: boolean
+  post: AppBskyFeedDefs.PostView
 }) {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
 
+  const isPrivate = post.$type === 'social.spkeasy.feed.defs#privatePostView'
+  const replyLabel = isPrivate ? 'Private reply:' : 'Reply'
+
   let label
   if (blocked) {
-    label = <Trans context="description">Reply to a blocked post</Trans>
+    label = <Trans context="description">{replyLabel} to a blocked post</Trans>
   } else if (notFound) {
-    label = <Trans context="description">Reply to a post</Trans>
+    label = <Trans context="description">{replyLabel} to a post</Trans>
   } else if (profile != null) {
     const isMe = profile.did === currentAccount?.did
     if (isMe) {
-      label = <Trans context="description">Reply to you</Trans>
+      label = <Trans context="description">{replyLabel} to you</Trans>
     } else {
       label = (
         <Trans context="description">
-          Reply to{' '}
+          {replyLabel} to{' '}
           <ProfileHoverCard inline did={profile.did}>
             <TextLinkOnWebOnly
               type="md"


### PR DESCRIPTION
**💫 What have you changed?**
- Add support for displaying private post notifications

**🎟️ Which issue does this solve?**
- Partial fix for #59 

**🧪 How can this be tested or verified?**
1. Login as Alice and trust Carla and Bob
2. Create a private post
3. Login as Bob, trust Alice and Carla (notification will not appear if you skip this)
4. Reply to Alice
5. Login as Carla
6. Trust Alice but not Bob
7. Reply to Bob

Everyone will be notified of replies, except Bob won't be notified of Carla's reply

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>