### PR TITLE
Show '? trusted' while trusted account is loading

### DIFF
--- a/src/screens/Profile/Header/Metrics.tsx
+++ b/src/screens/Profile/Header/Metrics.tsx
@@ -31,7 +31,8 @@ export function ProfileHeaderMetrics({
     one: 'following',
     other: 'following',
   })
-  const {data: trustedCount} = useTrustedUserCount(currentAccount?.did)
+  const {data: trustedCount, isLoading: isTrustedCountLoading} =
+    useTrustedUserCount(currentAccount?.did)
 
   return (
     <View
@@ -61,8 +62,10 @@ export function ProfileHeaderMetrics({
         <InlineLinkText
           style={[a.flex_row, t.atoms.text]}
           to="/trusted"
-          label={`${trustedCount || 0} trusted`}>
-          <Text style={[a.font_bold, a.text_md]}>{trustedCount || 0} </Text>
+          label={`${isTrustedCountLoading ? '?' : trustedCount || 0} trusted`}>
+          <Text style={[a.font_bold, a.text_md]}>
+            {isTrustedCountLoading ? '?' : trustedCount || 0}{' '}
+          </Text>
           <Text
             style={[t.atoms.text_contrast_medium, a.font_normal, a.text_md]}>
             trusted


### PR DESCRIPTION
Claude output:

Now when a user views their profile:
- While the trusted count is loading, it displays "? trusted" (with the link still clickable)
- Once Loaded, it displays the actual number or 0
- The Link to /trusted remains present and clickable throughout

The fix addresses the issue requirements perfectly!

**🤓 What should we check?**
- point

**💫 What have you changed?**
- point

**🎟️ Which issue does this solve?**
- This PR resolves https://github.com/speakeasy-social/speakeasy/issues/125

**🧪 How can this be tested or verified?**
- point

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>