### PR TITLE
Add a conditional for isLoading

### DIFF
--- a/src/screens/Profile/TrustedUsers.tsx
+++ b/src/screens/Profile/TrustedUsers.tsx
@@ -74,7 +74,7 @@ export const ProfileTrustedUsersScreen = (_props: Props) => {
     }, [setMinimalShellMode]),
   )
 
-  if (!trustedProfiles?.length) {
+  if (isLoading || !trustedProfiles?.length) {
     return (
       <Layout.Screen>
         <ViewHeader title={_(msg`Trusted Users`)} />


### PR DESCRIPTION
Claude output:

How this fixes the issue:

  1. During loading: isLoading is true, so we enter the block and ListMaybePlaceholder receives
  isLoading={true}, displaying the loader immediately
  2. After loading with no results: isLoading is false but !trustedProfiles?.length is true, so we
  show the empty state
  3. After loading with results: Both conditions are false, so we skip this block and display the
  list

**🤓 What should we check?**
- point

**💫 What have you changed?**
- point

**🎟️ Which issue does this solve?**
- This PR resolves https://github.com/speakeasy-social/speakeasy/issues/126

**🧪 How can this be tested or verified?**
- point

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>