### PR TITLE
Private notifications timeout

### DIFF
--- a/src/lib/async/timeout.ts
+++ b/src/lib/async/timeout.ts
@@ -1,3 +1,24 @@
 export function timeout(ms: number): Promise<void> {
   return new Promise(r => setTimeout(r, ms))
 }
+
+/**
+ * Wraps a promise with a timeout. If the promise doesn't resolve within the specified time,
+ * returns the fallback value instead.
+ * @param promise - The promise to wrap
+ * @param timeoutMs - Timeout in milliseconds
+ * @param fallbackValue - Value to return if the promise times out
+ * @returns Promise that resolves to either the promise result or the fallback value
+ */
+export function awaitWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallbackValue: T,
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>(resolve =>
+      setTimeout(() => resolve(fallbackValue), timeoutMs),
+    ),
+  ])
+}

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -26,6 +26,7 @@ import {
 } from '#/lib/api/private-notifications'
 import {callSpeakeasyApiWithAgent} from '#/lib/api/speakeasy'
 import {getCachedPrivateKey} from '#/lib/api/user-keys'
+import {awaitWithTimeout} from '#/lib/async/timeout'
 import {labelIsHideableOffense} from '#/lib/moderation'
 import {precacheProfile} from '../profile'
 import {FeedNotification, FeedPage, NotificationType} from './types'
@@ -80,7 +81,14 @@ export async function fetchPage({
           notifications: [],
           cursor: 'EOF',
         })
-      : listPrivateNotifications(agent, privateCursor, limit),
+      : awaitWithTimeout(
+          listPrivateNotifications(agent, privateCursor, limit),
+          30 * 1000, // 30 second timeout
+          {
+            notifications: [],
+            cursor: 'EOF',
+          },
+        ),
   ])
 
   const mergedCursor = mergeCursors(regularRes.data.cursor, privateRes.cursor)


### PR DESCRIPTION
Claude output:

Changes Summary

  1. Created shared utility function (src/lib/async/timeout.ts)
  - Added a generic awaitWithTimeout<T> function that wraps any promise with a timeout
  - If the promise doesn't resolve within the specified time, it returns a fallback value
  - This can be reused across the codebase for similar timeout scenarios

  2. Updated notifications loading (src/state/queries/notifications/util.ts)
  - Imported the new awaitWithTimeout utility (line 29)
  - Wrapped the listPrivateNotifications call with a 30-second timeout (lines 84-91)
  - If the private notifications API hangs or is slow, it now times out after 30 seconds
  - Returns empty notifications with cursor 'EOF' on timeout, allowing regular notifications to
  display

  How This Fixes the Issue

  Previously, if the private notifications API hung, the entire notifications screen would remain on
   the spinner indefinitely. Now:

  1. Regular notifications load normally - They're not blocked by private notifications
  2. 30-second safety net - If private notifications don't respond within 30 seconds, the timeout
  triggers
  3. Graceful degradation - Users see their regular notifications even if private notifications fail
  4. No more infinite spinners - The screen will load with whatever data is available

**🤓 What should we check?**
- point

**💫 What have you changed?**
- point

**🎟️ Which issue does this solve?**
- This PR resolves https://github.com/speakeasy-social/speakeasy/issues/128

**🧪 How can this be tested or verified?**
- point

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>