### PR TITLE
Fix typecheck issues

### DIFF
--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -56,8 +56,13 @@ export function Post({
   const record = useMemo<AppBskyFeedPost.Record | undefined>(() => {
     // if (post.record?.reply?.parent && !post.record?.reply?.parent?.uri) post.record.reply.parent.uri = 'at://placeholder'
     // Necessary for message to render properly when parent is missing
-    if (post.record?.reply?.parent && !post.record?.reply?.parent?.uri)
+    if (
+      AppBskyFeedPost.isRecord(post.record) &&
+      post.record.reply?.parent &&
+      !post.record.reply?.parent?.uri
+    ) {
       delete post.record.reply
+    }
     return AppBskyFeedPost.isRecord(post.record) &&
       AppBskyFeedPost.validateRecord(post.record).success
       ? post.record

--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -207,21 +207,23 @@ function Toast({
             ]}>
             <GestureDetector gesture={panGesture}>
               <View style={[a.flex_1, a.px_md, a.py_lg, a.flex_row, a.gap_md]}>
-                <View
-                  style={[
-                    a.flex_shrink_0,
-                    a.rounded_full,
-                    {width: 32, height: 32},
-                    {backgroundColor: t.palette.primary_50},
-                    a.align_center,
-                    a.justify_center,
-                  ]}>
-                  <FontAwesomeIcon
-                    icon={icon}
-                    size={16}
-                    style={t.atoms.text_contrast_medium}
-                  />
-                </View>
+                {icon && (
+                  <View
+                    style={[
+                      a.flex_shrink_0,
+                      a.rounded_full,
+                      {width: 32, height: 32},
+                      {backgroundColor: t.palette.primary_50},
+                      a.align_center,
+                      a.justify_center,
+                    ]}>
+                    <FontAwesomeIcon
+                      icon={icon}
+                      size={16}
+                      style={t.atoms.text_contrast_medium}
+                    />
+                  </View>
+                )}
                 <View style={[a.h_full, a.justify_center, a.flex_1]}>
                   <Text style={a.text_md} emoji>
                     {message}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Safely handle missing reply parent URIs in posts and only render toast icon when provided.
> 
> - **Post (`src/view/com/post/Post.tsx`)**:
>   - Guard reply cleanup with `AppBskyFeedPost.isRecord` before deleting `post.record.reply` when `reply.parent.uri` is missing.
> - **Toast (`src/view/com/util/Toast.tsx`)**:
>   - Render icon container only when `icon` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3662be811f8635f0c0e2cac00620a3852fdf368e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->