### PR TITLE
Fix notifications timeout - stop retries and add fetchSubjects timeout

### DIFF
--- a/src/lib/api/private-notifications.ts
+++ b/src/lib/api/private-notifications.ts
@@ -67,7 +67,7 @@ export async function listPrivateNotifications(
     console.error('Error listing private notifications:', error)
     return {
       notifications: [],
-      cursor: undefined,
+      cursor: 'EOF', // Stop retrying on error/timeout
     }
   }
 }


### PR DESCRIPTION
Two additional fixes to prevent notifications screen from hanging:

1. Return cursor: 'EOF' on error/timeout in listPrivateNotifications to prevent infinite retry loops

2. Add 3 second timeout protection to fetchSubjects for private post decryption - skip fetching if no private posts to avoid unnecessary API calls that could hang

Fixes #128

**🤓 What should we check?**
- point

**💫 What have you changed?**
- point

**🎟️ Which issue does this solve?**
- This PR resolves 

**🧪 How can this be tested or verified?**
- point

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>