### PR TITLE
Require trust when replying

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -884,7 +884,7 @@ function TrustRequiredBanner({
         <Lock size="sm" fill={t.palette.primary_500} />
         <NewText style={[a.flex_1, a.leading_snug]}>
           {_(
-            msg`To reply to a private post, you must trust the author so that they can see your reply`,
+            msg`To reply with a private post, you must trust the author so that they can see your reply`,
           )}
         </NewText>
         <Button


### PR DESCRIPTION
When replying to a private post, users must now trust the author so that their reply is visible to the recipient. This addresses an issue where replies to private posts could be hidden from the intended recipient.

Changes:
- Add trust status check when replying to private posts
- Show TrustRequiredBanner with Trust button when author is not trusted
- Disable Post button until trust relationship is established
- Once trusted, show standard TrustedAudienceBanner and enable posting

Fixes #95

**🤓 What should we check?**
- point

**💫 What have you changed?**
- point

**🎟️ Which issue does this solve?**
- This PR resolves 

**🧪 How can this be tested or verified?**
- point

**🖼️ Expected results**
<details>
    <summary>Toggle Screenshot</summary>
</details>