### PR TITLE
Fix undo link not working in Toast notifications

### DIFF
--- a/src/view/com/util/Toast.web.tsx
+++ b/src/view/com/util/Toast.web.tsx
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     marginLeft: 10,
+    zIndex: 1,
   },
   dismissBackdrop: {
     position: 'absolute',
@@ -118,10 +119,12 @@ const styles = StyleSheet.create({
     left: 0,
     bottom: 0,
     right: 0,
+    zIndex: 0,
   },
   icon: {
     color: '#fff',
     flexShrink: 0,
+    zIndex: 1,
   },
   text: {
     color: '#fff',


### PR DESCRIPTION
The dismissBackdrop was positioned absolutely over the entire toast and rendered after the link, causing it to intercept all click events before they reached the undo link. Added zIndex styling to ensure the content (with the link) and icon appear above the backdrop so clicks on the link work correctly.

Fixes #110

