### PR TITLE
Add invite link deep linking support

### DIFF
--- a/src/components/dialogs/LimitedBetaModal.tsx
+++ b/src/components/dialogs/LimitedBetaModal.tsx
@@ -25,6 +25,7 @@ export interface LimitedBetaModalProps {
   }
   onSuccess?: () => void
   onCancel?: () => void
+  initialCode?: string
 }
 
 export function LimitedBetaModal({
@@ -34,6 +35,7 @@ export function LimitedBetaModal({
   utmParams,
   onSuccess,
   onCancel,
+  initialCode,
 }: LimitedBetaModalProps) {
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
@@ -52,11 +54,17 @@ export function LimitedBetaModal({
   React.useEffect(() => {
     if (control.isOpen) {
       wasSuccessfulRef.current = false
-      setShowInviteCode(false)
-      setCode('')
+      // If initialCode is provided, skip to invite code entry with code pre-filled
+      if (initialCode) {
+        setShowInviteCode(true)
+        setCode(initialCode)
+      } else {
+        setShowInviteCode(false)
+        setCode('')
+      }
       setError(null)
     }
-  }, [control.isOpen])
+  }, [control.isOpen, initialCode])
 
   const applyInviteCode = useMutation({
     mutationFn: async (inviteCode: string) => {

--- a/src/components/intents/IntentDialogs.tsx
+++ b/src/components/intents/IntentDialogs.tsx
@@ -2,12 +2,16 @@ import React from 'react'
 
 import * as Dialog from '#/components/Dialog'
 import {DialogControlProps} from '#/components/Dialog'
+import {InviteIntentDialog} from '#/components/intents/InviteIntentDialog'
 import {VerifyEmailIntentDialog} from '#/components/intents/VerifyEmailIntentDialog'
 
 interface Context {
   verifyEmailDialogControl: DialogControlProps
   verifyEmailState: {code: string} | undefined
   setVerifyEmailState: (state: {code: string} | undefined) => void
+  inviteDialogControl: DialogControlProps
+  inviteState: {code: string} | undefined
+  setInviteState: (state: {code: string} | undefined) => void
 }
 
 const Context = React.createContext({} as Context)
@@ -18,20 +22,35 @@ export function Provider({children}: {children: React.ReactNode}) {
   const [verifyEmailState, setVerifyEmailState] = React.useState<
     {code: string} | undefined
   >()
+  const inviteDialogControl = Dialog.useDialogControl()
+  const [inviteState, setInviteState] = React.useState<
+    {code: string} | undefined
+  >()
 
   const value = React.useMemo(
     () => ({
       verifyEmailDialogControl,
       verifyEmailState,
       setVerifyEmailState,
+      inviteDialogControl,
+      inviteState,
+      setInviteState,
     }),
-    [verifyEmailDialogControl, verifyEmailState, setVerifyEmailState],
+    [
+      verifyEmailDialogControl,
+      verifyEmailState,
+      setVerifyEmailState,
+      inviteDialogControl,
+      inviteState,
+      setInviteState,
+    ],
   )
 
   return (
     <Context.Provider value={value}>
       {children}
       <VerifyEmailIntentDialog />
+      <InviteIntentDialog />
     </Context.Provider>
   )
 }

--- a/src/components/intents/InviteIntentDialog.tsx
+++ b/src/components/intents/InviteIntentDialog.tsx
@@ -1,0 +1,26 @@
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {LimitedBetaModal} from '#/components/dialogs/LimitedBetaModal'
+import {useIntentDialogs} from '#/components/intents/IntentDialogs'
+
+export function InviteIntentDialog() {
+  const {_} = useLingui()
+  const {inviteDialogControl: control, inviteState: state} = useIntentDialogs()
+
+  return (
+    <LimitedBetaModal
+      control={control}
+      featureName={_(msg`Private Post to Trusted Communities`)}
+      featureDescription={_(
+        msg`We're trialing a new feature to make your posts only visible to your trusted community.`,
+      )}
+      utmParams={{
+        source: 'invite_link',
+        medium: 'deep_link',
+        campaign: 'beta_features',
+      }}
+      initialCode={state?.code}
+    />
+  )
+}

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -9,7 +9,7 @@ import {useCloseAllActiveElements} from '#/state/util'
 import {useIntentDialogs} from '#/components/intents/IntentDialogs'
 import {Referrer} from '../../../modules/expo-bluesky-swiss-army'
 
-type IntentType = 'compose' | 'verify-email'
+type IntentType = 'compose' | 'verify-email' | 'invite'
 
 const VALID_IMAGE_REGEX = /^[\w.:\-_/]+\|\d+(\.\d+)?\|\d+(\.\d+)?$/
 
@@ -20,6 +20,7 @@ export function useIntentHandler() {
   const incomingUrl = Linking.useURL()
   const composeIntent = useComposeIntent()
   const verifyEmailIntent = useVerifyEmailIntent()
+  const inviteIntent = useInviteIntent()
 
   React.useEffect(() => {
     const handleIncomingURL = (url: string) => {
@@ -71,6 +72,12 @@ export function useIntentHandler() {
           verifyEmailIntent(code)
           return
         }
+        case 'invite': {
+          const code = params.get('code')
+          if (!code) return
+          inviteIntent(code)
+          return
+        }
         default: {
           return
         }
@@ -84,7 +91,7 @@ export function useIntentHandler() {
       handleIncomingURL(incomingUrl)
       previousIntentUrl = incomingUrl
     }
-  }, [incomingUrl, composeIntent, verifyEmailIntent])
+  }, [incomingUrl, composeIntent, verifyEmailIntent, inviteIntent])
 }
 
 export function useComposeIntent() {
@@ -155,6 +162,24 @@ export function useComposeIntent() {
 function useVerifyEmailIntent() {
   const closeAllActiveElements = useCloseAllActiveElements()
   const {verifyEmailDialogControl: control, setVerifyEmailState: setState} =
+    useIntentDialogs()
+  return React.useCallback(
+    (code: string) => {
+      closeAllActiveElements()
+      setState({
+        code,
+      })
+      setTimeout(() => {
+        control.open()
+      }, 1000)
+    },
+    [closeAllActiveElements, control, setState],
+  )
+}
+
+function useInviteIntent() {
+  const closeAllActiveElements = useCloseAllActiveElements()
+  const {inviteDialogControl: control, setInviteState: setState} =
     useIntentDialogs()
   return React.useCallback(
     (code: string) => {


### PR DESCRIPTION
Fixes #152 

- Add /invite route for direct invite URLs
- Handle 'invite' intent type in useIntentHandler
- Support both  /intent/invite?code=... URL formats
- Add InviteIntentDialog component that reuses LimitedBetaModal
- Add initialCode prop to LimitedBetaModal for pre-filling invite codes
